### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Searching has been removed for now but will hopefully be added back in future as
 
 For full instructions on use see: http://www.ssbits.com/tutorials/2012/dataobject-as-pages-the-module/
 
-##Versioning
+## Versioning
 
 Versioning is now optional, you can enable it by adding the following line to you _config.php
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
